### PR TITLE
Add lib folder with .gitignore

### DIFF
--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,0 +1,1 @@
+libgsl.a


### PR DESCRIPTION
When trying to build, one gets
```julia
$ make
cd gsl-1.5/poly; make
make[1]: Entering directory '/home/blegat/git/sdplr/gsl-1.5/poly'
gcc -g -fPIC   -c -o eval.o eval.c
gcc -g -fPIC   -c -o solve_cubic.o solve_cubic.c
ar cr ../../lib/libgsl.a eval.o solve_cubic.o
ar: ../../lib/libgsl.a: No such file or directory
make[1]: *** [Makefile:5: gsl] Error 1
make[1]: Leaving directory '/home/blegat/git/sdplr/gsl-1.5/poly'
make: *** [Makefile:4: gsl] Error 2
```
This is due to the fact that there is no `lib` folder. It's not possible to add an empty `lib` folder because [`git` does not allow committing an empty folder](https://stackoverflow.com/questions/115983/how-do-i-add-an-empty-directory-to-a-git-repository). To fix this, this PR adds a `.gitignore` file in this folder saying that `libgsl.a` should be ignored.