### PR TITLE
Fix linesearch for non-cubic derivative

### DIFF
--- a/gsl-1.5/poly/Makefile
+++ b/gsl-1.5/poly/Makefile
@@ -1,8 +1,8 @@
 include ../../Makefile.inc
 
 
-gsl: eval.o solve_cubic.o 
-	ar cr ../../lib/libgsl.a eval.o solve_cubic.o
+gsl: eval.o solve_quadratic.o solve_cubic.o
+	ar cr ../../lib/libgsl.a eval.o solve_quadratic.o solve_cubic.o
 
 
 clean:

--- a/gsl-1.5/poly/solve_quadratic.c
+++ b/gsl-1.5/poly/solve_quadratic.c
@@ -1,0 +1,88 @@
+/* poly/solve_quadratic.c
+ * 
+ * Copyright (C) 1996, 1997, 1998, 1999, 2000, 2007 Brian Gough
+ * 
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or (at
+ * your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+/* solve_quadratic.c - finds the real roots of a x^2 + b x + c = 0 */
+
+#include <config.h>
+#include <math.h>
+
+#include <gsl/gsl_poly.h>
+
+int 
+gsl_poly_solve_quadratic (double a, double b, double c, 
+                          double *x0, double *x1)
+{
+  if (a == 0) /* Handle linear case */
+    {
+      if (b == 0)
+        {
+          return 0;
+        }
+      else
+        {
+          *x0 = -c / b;
+          return 1;
+        };
+    }
+
+  {
+    double disc = b * b - 4 * a * c;
+    
+    if (disc > 0)
+      {
+        if (b == 0)
+          {
+            double r = sqrt (-c / a);
+            *x0 = -r;
+            *x1 =  r;
+          }
+        else
+          {
+            double sgnb = (b > 0 ? 1 : -1);
+            double temp = -0.5 * (b + sgnb * sqrt (disc));
+            double r1 = temp / a ;
+            double r2 = c / temp ;
+            
+            if (r1 < r2) 
+              {
+                *x0 = r1 ;
+                *x1 = r2 ;
+              } 
+            else 
+              {
+                *x0 = r2 ;
+                  *x1 = r1 ;
+              }
+          }
+        return 2;
+      }
+    else if (disc == 0) 
+      {
+        *x0 = -0.5 * b / a ;
+        *x1 = -0.5 * b / a ;
+        return 2 ;
+      }
+    else
+      {
+        return 0;
+      }
+  }
+}
+
+

--- a/gsl-1.5/poly/solve_quadratic.c
+++ b/gsl-1.5/poly/solve_quadratic.c
@@ -19,12 +19,11 @@
 
 /* solve_quadratic.c - finds the real roots of a x^2 + b x + c = 0 */
 
-#include <config.h>
+//#include <config.h>
 #include <math.h>
+#include "gsl_poly.h"
 
-#include <gsl/gsl_poly.h>
-
-int 
+size_t
 gsl_poly_solve_quadratic (double a, double b, double c, 
                           double *x0, double *x1)
 {

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,0 +1,1 @@
+libgsl.a

--- a/source/protoext.h
+++ b/source/protoext.h
@@ -15,6 +15,7 @@ extern void dseupd_();
 extern void dsyev_(char*, char*, size_t*, double*, size_t*, double*, double*, size_t*, size_t*);
 extern void dtrmm_();
 extern size_t idamax_(size_t*, double*, size_t*);
+extern size_t gsl_poly_solve_quadratic(double, double, double, double*, double*);
 extern size_t gsl_poly_solve_cubic(double, double, double, double*, double*, double*);
 extern double gsl_poly_eval(double*, size_t, double);
 extern size_t daxpy_(size_t*, double*, double*, size_t*, double*, size_t*);


### PR DESCRIPTION
JuMP has a small [test suite](https://jump.dev/MathOptInterface.jl/stable/submodules/Test/overview/) that is used to tests whether a solver wrapper is correctly implemented.
When running SDPLR against this test suite, I often get this `Surprise! Got a quadratic function!`. The issue is that since it is calling `exit(0)`, it also exists the Julia process and since it is a `0`, it means success so the tests are actually ending with a green sign even if they actually failed. See for instance:
https://github.com/blegat/SDPLR.jl/actions/runs/7171704147/job/19527265190#step:6:243
This motivates this PR that tries to handle this case. It's a bit difficult to give a minimal reproducing example since getting into this situation of non-cubic function is not so reproducible.
Running the whole test suite locally with this fix (and adding the printing of the quartic polynomial and it's derivative) gives me the following for the test `MathOptInterface.Test.test_modification_const_vectoraffine_zeros`:
```
            ***   SDPLR 1.03-beta   ***

===================================================
 major   minor        val        infeas      time  
---------------------------------------------------
    1        3   5.20283613e+00  6.1e+00       0
    2        6   8.49082566e-03  2.1e-01       0
    3        7   7.55103955e-03  7.0e-02       0
    4        9   1.35260274e-03  3.7e-02       0
    5       11   1.99266008e-10  1.0e-05       0
Surprise! Got a quadratic function!
Quartic: 1.141961527636525433e-19 x^4 + -1.034865046947459975e-09 x^3 + 2.344535172309506255e+00 x^2 + -1.680858815129947074e-04 x + 3.293142071938505191e-09
Cubic: 4.567846110546101734e-19 x^3 + -3.104595140842379718e-09 x^2 + 4.689070344619012509e+00 x + -1.680858815129947074e-04
d = 2
max = 1.000000000000000000e+00
roots[0] = 3.584631262908803142e-05
f1 = 2.805125433132000194e-10
roots[1] = 1.510364518365702629e+09
f2 = 1.000000000000000000e+20
ss = 3.584631262908803142e-05
    6       12   8.14684445e-10  2.9e-06       0
===================================================
```
and `MathOptInterface.Test.test_linear_modify_GreaterThan_and_LessThan_constraints`:
```
            ***   SDPLR 1.03-beta   ***

===================================================
 major   minor        val        infeas      time  
---------------------------------------------------
    1        0  -8.93311995e-02  2.6e-01       0
    2        6   3.17224013e+00  4.3e+00       0
    3        8   2.85268274e-03  7.1e-02       0
    4        9   8.09517727e-04  3.2e-02       0
    5       10   2.39585980e-04  6.5e-03       0
    6       12   9.77962820e-05  3.4e-03       0
    7       15   8.38457735e-08  1.7e-04       0
    8       16   7.09974639e-08  5.8e-05       0
Surprise! Got a quadratic function!
Quartic: 3.535751696825145105e-17 x^4 + -1.428099373166241155e-09 x^3 + 1.656643644316178540e-02 x^2 + -8.511548027070006846e-05 x + 1.070915447164440552e-07
Cubic: 1.414300678730058042e-16 x^3 + -4.284298119498723670e-09 x^2 + 3.313287288632357080e-02 x + -8.511548027070006846e-05
d = 2
max = 1.000000000000000000e+00
roots[0] = 2.568913374671686831e-03
f1 = -2.235603100953340720e-09
roots[1] = 7.733559138782393187e+06
f2 = 1.000000000000000000e+20
ss = 2.568913374671686831e-03
    9       17   1.06586738e-08  1.7e-05       0
Surprise! Got a quadratic function!
Quartic: 2.423100490040932654e-17 x^4 + -6.381103462798253914e-10 x^3 + 2.160544059270731038e-02 x^2 + -3.900344712295257369e-05 x + 1.710581232168087618e-08
Cubic: 9.692401960163730616e-17 x^3 + -1.914331038839475967e-09 x^2 + 4.321088118541462075e-02 x + -3.900344712295257369e-05
d = 2
max = 1.000000000000000000e+00
roots[0] = 9.026302184663030680e-04
f1 = -4.970326768492759075e-10
roots[1] = 2.257231393473220617e+07
f2 = 1.000000000000000000e+20
ss = 9.026302184663030680e-04
   10       18   3.28130467e-09  6.7e-06       0
===================================================

DIMACS error measures: 6.65e-06 0.00e+00 0.00e+00 2.93e-04 -9.38e-06 5.17e-09
```
and `MathOptInterface.Test.test_linear_VectorAffineFunction`:
```
            ***   SDPLR 1.03-beta   ***

===================================================
 major   minor        val        infeas      time  
---------------------------------------------------
    1        0  -8.93311995e-02  2.6e-01       0
    2        6   3.17224013e+00  4.3e+00       0
    3        8   2.85268274e-03  7.1e-02       0
    4        9   8.09517727e-04  3.2e-02       0
    5       10   2.39585980e-04  6.5e-03       0
    6       12   9.77962820e-05  3.4e-03       0
    7       15   8.38457735e-08  1.7e-04       0
    8       16   7.09974639e-08  5.8e-05       0
Surprise! Got a quadratic function!
Quartic: 3.535751696825145105e-17 x^4 + -1.428099373166241155e-09 x^3 + 1.656643644316178540e-02 x^2 + -8.511548027070006846e-05 x + 1.070915447164440552e-07
Cubic: 1.414300678730058042e-16 x^3 + -4.284298119498723670e-09 x^2 + 3.313287288632357080e-02 x + -8.511548027070006846e-05
d = 2
max = 1.000000000000000000e+00
roots[0] = 2.568913374671686831e-03
f1 = -2.235603100953340720e-09
roots[1] = 7.733559138782393187e+06
f2 = 1.000000000000000000e+20
ss = 2.568913374671686831e-03
    9       17   1.06586738e-08  1.7e-05       0
Surprise! Got a quadratic function!
Quartic: 2.423100490040932654e-17 x^4 + -6.381103462798253914e-10 x^3 + 2.160544059270731038e-02 x^2 + -3.900344712295257369e-05 x + 1.710581232168087618e-08
Cubic: 9.692401960163730616e-17 x^3 + -1.914331038839475967e-09 x^2 + 4.321088118541462075e-02 x + -3.900344712295257369e-05
d = 2
max = 1.000000000000000000e+00
roots[0] = 9.026302184663030680e-04
f1 = -4.970326768492759075e-10
roots[1] = 2.257231393473220617e+07
f2 = 1.000000000000000000e+20
ss = 9.026302184663030680e-04
   10       18   3.28130467e-09  6.7e-06       0
===================================================

DIMACS error measures: 6.65e-06 0.00e+00 0.00e+00 2.93e-04 -9.38e-06 5.17e-09
```

As you can see, the fix of this PR seems work quite well.