### PR TITLE
Use signed type for nnz as low-rank is tagged with negative value

### DIFF
--- a/source/readdata.c
+++ b/source/readdata.c
@@ -496,7 +496,7 @@ size_t readdata_sdplr(char* datafilename, size_t* passed_m, size_t* passed_numbl
   // and no error checking is done at all.
 
   size_t i, j, k, pos1, pos2, num, blk, sz;
-  size_t *nnz;
+  int *nnz;
   size_t ct, specindex;
   double entry;
   char type;
@@ -557,7 +557,7 @@ size_t readdata_sdplr(char* datafilename, size_t* passed_m, size_t* passed_numbl
   ret = fscanf(datafile, "%lf", &entry);
 
   // Prepare for next step  
-  MYCALLOC(nnz, size_t, (m+1)*numblk);
+  MYCALLOC(nnz, int, (m+1)*numblk);
 
   // Determine how many nnz entries are in each (data matrix)-(block) pair
   // This needs work!
@@ -609,8 +609,8 @@ size_t readdata_sdplr(char* datafilename, size_t* passed_m, size_t* passed_numbl
       specindex = DATABLOCKIND(i,blk,numblk);
       CAinfo_entptr[specindex] = ct;
       CAinfo_rowcolptr[specindex] = ct;
-      if(nnz[specindex] > 0) ct += nnz[specindex]; // sparse matrix
-      else ct += -nnz[specindex]; // low-rank matrix
+      if (nnz[specindex] > 0) ct += nnz[specindex]; // sparse matrix
+      else ct -= nnz[specindex]; // low-rank matrix
 
       if(nnz[specindex] > 0) CAinfo_storage[specindex] = 's'; // sparse matrix (sparse)
       else CAinfo_storage[specindex] = 'd'; // low-rank matrix (dense)


### PR DESCRIPTION
As `nnz` was `size_t`, the condition `nnz[specindex] > 0` on line 612 is always true.
On the documentation example (added in https://github.com/sburer/sdplr/pull/6 for easier testing), before this PR, I get
```sh
$ ./sdplr data/doc.dat-s.sdplr sdplr.params
Fatal glibc error: malloc.c:4434 (_int_malloc): assertion failed: (unsigned long) (size) >= (unsigned long) (nb)
[1]    241768 IOT instruction (core dumped)  ./sdplr doc.dat-s.sdplr sdplr.params
```
This is because, when converting the small negative number to `size_t` we get a large negative number which is then passed to `malloc` which complains that this is too large.
After this PR I get:
```sh
$ ./sdplr data/doc.dat-s.sdplr sdplr.params 

            ***   SDPLR 1.03-beta   ***

===================================================
 major   minor        val        infeas      time  
---------------------------------------------------
    1        4   3.12144338e+01  9.3e+00       0
    2        5  -2.42669782e+00  3.3e-01       0
    3       12  -2.18942454e+00  1.3e-01       0
    4       14  -2.23524651e+00  5.1e-03       0
    5       18  -2.23579016e+00  3.8e-03       0
    6       22  -2.23605551e+00  8.7e-04       0
    7       24  -2.23606250e+00  2.4e-04       0
    8       27  -2.23606566e+00  4.5e-05       0
    9       32  -2.23606772e+00  1.5e-05       0
   10       33  -2.23606773e+00  5.4e-06       0
===================================================

DIMACS error measures: 5.42e-06 0.00e+00 0.00e+00 1.11e-03 -2.95e-05 -8.21e-05
```